### PR TITLE
remove distribution of HTML download page and return manifest url for download

### DIFF
--- a/lib/antenna/command/s3.rb
+++ b/lib/antenna/command/s3.rb
@@ -41,14 +41,14 @@ command :s3 do |c|
 
     s3 = Antenna::Distributor::S3.new(@access_key_id, @secret_access_key, @region, @endpoint)
     distributor = Antenna::Distributor.new(s3)
-    puts distributor.distribute @file, { 
-      :bucket => @bucket, 
-      :create => !!options.create, 
+    distributor.distribute @file, {
+      :bucket => @bucket,
+      :create => !!options.create,
       :public => !!options.public,
-      :expire => options.expires, 
-      :acl    => options.acl, 
-      :base   => options.base 
-    } 
+      :expire => options.expires,
+      :acl    => options.acl,
+      :base   => options.base
+    }
   end
 
   private

--- a/lib/antenna/distributor.rb
+++ b/lib/antenna/distributor.rb
@@ -28,7 +28,7 @@ module Antenna
           app_icon,
           "#{base_filename}.png",
           "image/png",
-        ) 
+        )
       end
 
       # Distribute Manifest
@@ -38,19 +38,8 @@ module Antenna
         "#{base_filename}.plist",
         "text/xml",
       )
-      
-      # Distribute HTML
-      html = build_html(ipa, manifest_url, app_icon_url)
-      html_url = @distributor.distribute(
-        html.to_s,
-        "#{base_filename}.html",
-        "text/html",
-      )
 
-      # Let distributor clean things up (if necessary)
-      @distributor.teardown if @distributor.respond_to?(:teardown)
-
-      return html_url
+      manifest_url
     end
 
     private
@@ -65,10 +54,6 @@ module Antenna
 
     def build_manifest(ipa, ipa_url, app_icon_url)
       Antenna::Manifest.new(ipa_url, ipa.info_plist, app_icon_url)
-    end
-
-    def build_html(ipa, manifest_url, app_icon_url)
-      Antenna::HTML.new(ipa.info_plist, manifest_url, app_icon_url)
     end
   end
 end


### PR DESCRIPTION
We only want to distribute the `.ipa` file, the image and the manifest, and not the HTML page. This is necessary for the Canvas download page James is working on.
https://breeze.atlassian.net/browse/OPS-584